### PR TITLE
PR: Manage Discovery Server Instance

### DIFF
--- a/internal/resources/fleet.go
+++ b/internal/resources/fleet.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	fleetv1alpha1 "github.com/robolaunch/fleet-operator/pkg/api/roboscale.io/v1alpha1"
+	robotv1alpha1 "github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -16,4 +17,17 @@ func GetNamespace(fleet *fleetv1alpha1.Fleet, nsNamespacedName *types.Namespaced
 	}
 
 	return &namespace
+}
+
+func GetDiscoveryServer(fleet *fleetv1alpha1.Fleet, dsNamespacedName *types.NamespacedName) *robotv1alpha1.DiscoveryServer {
+
+	discoveryServer := robotv1alpha1.DiscoveryServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dsNamespacedName.Name,
+			Namespace: dsNamespacedName.Namespace,
+		},
+		Spec: fleet.Spec.DiscoveryServerTemplate,
+	}
+
+	return &discoveryServer
 }

--- a/internal/shared.go
+++ b/internal/shared.go
@@ -1,1 +1,7 @@
 package internal
+
+// Fleet resource postfixes
+
+const (
+	DISCOVERY_SERVER_FLEET_POSTFIX = "-discovery"
+)

--- a/pkg/api/roboscale.io/v1alpha1/fleet_types.go
+++ b/pkg/api/roboscale.io/v1alpha1/fleet_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/robolaunch/fleet-operator/internal"
 	robotv1alpha1 "github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -80,5 +81,12 @@ func init() {
 func (fleet *Fleet) GetNamespaceMetadata() *types.NamespacedName {
 	return &types.NamespacedName{
 		Name: fleet.Name,
+	}
+}
+
+func (fleet *Fleet) GetDiscoveryServerMetadata() *types.NamespacedName {
+	return &types.NamespacedName{
+		Name:      fleet.Name + internal.DISCOVERY_SERVER_FLEET_POSTFIX,
+		Namespace: fleet.Namespace,
 	}
 }

--- a/pkg/controllers/fleet/check.go
+++ b/pkg/controllers/fleet/check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	fleetv1alpha1 "github.com/robolaunch/fleet-operator/pkg/api/roboscale.io/v1alpha1"
+	robotv1alpha1 "github.com/robolaunch/robot-operator/pkg/api/roboscale.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
@@ -18,6 +19,22 @@ func (r *FleetReconciler) reconcileCheckNamespace(ctx context.Context, instance 
 		return err
 	} else {
 		instance.Status.NamespaceStatus.Created = true
+	}
+
+	return nil
+}
+
+func (r *FleetReconciler) reconcileCheckDiscoveryServer(ctx context.Context, instance *fleetv1alpha1.Fleet) error {
+
+	discoveryServerQuery := &robotv1alpha1.DiscoveryServer{}
+	err := r.Get(ctx, *instance.GetDiscoveryServerMetadata(), discoveryServerQuery)
+	if err != nil && errors.IsNotFound(err) {
+		instance.Status.DiscoveryServerStatus = fleetv1alpha1.DiscoveryServerInstanceStatus{}
+	} else if err != nil {
+		return err
+	} else {
+		instance.Status.DiscoveryServerStatus.Created = true
+		instance.Status.DiscoveryServerStatus.Status = discoveryServerQuery.Status
 	}
 
 	return nil

--- a/pkg/controllers/fleet/create.go
+++ b/pkg/controllers/fleet/create.go
@@ -29,3 +29,23 @@ func (r *FleetReconciler) createNamespace(ctx context.Context, instance *fleetv1
 	logger.Info("STATUS: Namespace " + ns.Name + " is created.")
 	return nil
 }
+
+func (r *FleetReconciler) createDiscoveryServer(ctx context.Context, instance *fleetv1alpha1.Fleet, dsNamespacedName *types.NamespacedName) error {
+
+	discoveryServer := resources.GetDiscoveryServer(instance, dsNamespacedName)
+
+	err := ctrl.SetControllerReference(instance, discoveryServer, r.Scheme)
+	if err != nil {
+		return err
+	}
+
+	err = r.Create(ctx, discoveryServer)
+	if err != nil && errors.IsAlreadyExists(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	logger.Info("STATUS: Discovery server " + discoveryServer.Name + " is created.")
+	return nil
+}

--- a/pkg/controllers/fleet/fleet_controller.go
+++ b/pkg/controllers/fleet/fleet_controller.go
@@ -101,7 +101,12 @@ func (r *FleetReconciler) reconcileCheckStatus(ctx context.Context, instance *fl
 
 		case false:
 
-			// create discovery server
+			instance.Status.Phase = fleetv1alpha1.FleetPhaseCreatingDiscoveryServer
+			err := r.createDiscoveryServer(ctx, instance, instance.GetDiscoveryServerMetadata())
+			if err != nil {
+				return err
+			}
+			instance.Status.DiscoveryServerStatus.Created = true
 
 		}
 

--- a/pkg/controllers/fleet/fleet_controller.go
+++ b/pkg/controllers/fleet/fleet_controller.go
@@ -131,6 +131,11 @@ func (r *FleetReconciler) reconcileCheckResources(ctx context.Context, instance 
 		return err
 	}
 
+	err = r.reconcileCheckDiscoveryServer(ctx, instance)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
# PR: Manage Discovery Server Instance

## Description

Fleet deploys a discovery server instance using template on it's manifest, then checks discovery server's status.

Closes #7 

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How can it be tested?

Filling `.spec.discoveryServerTemplate` field creates desired discovery server configuration for fleet.
