### PR TITLE
PR: Check FederatedNamespace's Remote Status Presence

### DIFF
--- a/pkg/controllers/fleet/check.go
+++ b/pkg/controllers/fleet/check.go
@@ -56,10 +56,12 @@ func (r *FleetReconciler) reconcileCheckNamespace(ctx context.Context, instance 
 				if unstructuredFedNs.Object["status"] != nil {
 					remoteStatusesInterface := unstructuredFedNs.Object["status"].(map[string]interface{})["clusters"].([]interface{})
 					for _, remoteStatus := range remoteStatusesInterface {
-						remoteObjectPhase := remoteStatus.(map[string]interface{})["remoteStatus"].(map[string]interface{})["phase"].(string)
-						if remoteObjectPhase != "Active" {
-							instance.Status.NamespaceStatus.Ready = false
-							break
+						if rs, ok := remoteStatus.(map[string]interface{})["remoteStatus"]; ok {
+							remoteObjectPhase := rs.(map[string]interface{})["phase"].(string)
+							if remoteObjectPhase != "Active" {
+								instance.Status.NamespaceStatus.Ready = false
+								break
+							}
 						}
 					}
 				} else {


### PR DESCRIPTION
# :herb: PR: Check FederatedNamespace's Remote Status Presence

## Description

- Clusters that has no remote status are ignored.

Closes #31 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How can it be tested?

Can be tested with the case mentioned in the related issue.
